### PR TITLE
Make annotation on enums be in the same line

### DIFF
--- a/eclipse/jboss-java-formatter.xml
+++ b/eclipse/jboss-java-formatter.xml
@@ -36,6 +36,7 @@
 <setting id="org.eclipse.jdt.core.formatter.insert_space_between_empty_parens_in_enum_constant" value="do not insert"/>
 <setting id="org.eclipse.jdt.core.formatter.insert_new_line_before_finally_in_try_statement" value="do not insert"/>
 <setting id="org.eclipse.jdt.core.formatter.insert_new_line_after_annotation_on_local_variable" value="insert"/>
+<setting id="org.eclipse.jdt.core.formatter.insert_new_line_after_annotation_on_enum_constant" value="do_not_insert"/>
 <setting id="org.eclipse.jdt.core.formatter.insert_new_line_before_catch_in_try_statement" value="do not insert"/>
 <setting id="org.eclipse.jdt.core.formatter.insert_space_before_opening_paren_in_while" value="insert"/>
 <setting id="org.eclipse.jdt.core.formatter.blank_lines_after_package" value="1"/>


### PR DESCRIPTION
This is done to avoid formatting like so:
```java
public enum BuildSystemType {
    @JsonProperty("koji")
    KOJI, @JsonProperty("pnc")
    PNC;
}
```

Instead, it will look like:
```java
public enum BuildSystemType {
    @JsonProperty("koji") KOJI,
    @JsonProperty("pnc") PNC;
}
```

Thanks to @dwalluck for pointing out this inconsistency